### PR TITLE
✨ feat: lobe-i18n - 添加 Markdown 文件翻译缓存功能 (#98)

### DIFF
--- a/packages/lobe-i18n/package.json
+++ b/packages/lobe-i18n/package.json
@@ -54,6 +54,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
+    "@deno/kv": "^0.7.0",
     "@inkjs/ui": "^1",
     "@langchain/core": "latest",
     "@langchain/openai": "latest",

--- a/packages/lobe-i18n/src/cache/index.ts
+++ b/packages/lobe-i18n/src/cache/index.ts
@@ -1,0 +1,37 @@
+import { Kv, openKv } from '@deno/kv';
+import crypto from 'node:crypto';
+
+export class FileHashCache {
+  kv: Promise<Kv>;
+  constructor(cacheDB = '.lobe-i18n.db') {
+    this.kv = openKv(cacheDB);
+  }
+  getHash(fileContent: string) {
+    return crypto.createHash('md5').update(fileContent).digest('hex');
+  }
+  setHash(filePath: string, key: string) {
+    return this.kv.then((kv) => {
+      return kv.set(['files', filePath], key);
+    });
+  }
+  hasHash(filePath: string, key: string) {
+    return this.kv
+      .then((kv) => {
+        return kv.get<string>(['files', filePath]);
+      })
+      .then((res) => {
+        return res.value === key;
+      });
+  }
+  remove(filePath: string) {
+    return this.kv.then((kv) => kv.delete(['files', filePath]));
+  }
+  clear() {
+    return this.kv.then((kv) => {
+      return kv.delete(['files']);
+    });
+  }
+  destory() {
+    return this.kv.then((kv) => kv.close());
+  }
+}

--- a/packages/lobe-i18n/src/cache/index.ts
+++ b/packages/lobe-i18n/src/cache/index.ts
@@ -27,8 +27,9 @@ export class FileHashCache {
     return this.kv.then((kv) => kv.delete(['files', filePath]));
   }
   clear() {
-    return this.kv.then((kv) => {
-      return kv.delete(['files']);
+    return this.kv.then(async (kv) => {
+      const iter = kv.list<string>({ prefix: ['files'] });
+      for await (const res of iter) kv.delete(res.key);
     });
   }
   destory() {

--- a/packages/lobe-i18n/src/cli.tsx
+++ b/packages/lobe-i18n/src/cli.tsx
@@ -16,6 +16,7 @@ notifier.notify({ isGlobal: true });
 const program = new Command();
 
 interface Flags {
+  clear?: boolean;
   config?: string;
   option?: boolean;
   withMd?: boolean;
@@ -27,6 +28,7 @@ program
   .version(packageJson.version)
   .addOption(new Option('-o, --option', 'Setup lobe-i18n preferences'))
   .addOption(new Option('-c, --config <string>', 'Specify the configuration file'))
+  .addOption(new Option('--clear', 'clear cache'))
   .addOption(
     new Option('-m, --with-md', 'Run i18n translation and markdown translation simultaneously'),
   );
@@ -45,7 +47,11 @@ program.command('locale', { isDefault: true }).action(async () => {
 program.command('md').action(async () => {
   const options: Flags = program.opts();
   if (options.config) explorer.loadCustomConfig(options.config);
-  await new TranslateMarkdown().start();
+  const service = new TranslateMarkdown();
+  if (options.clear) {
+    await service.fileHashCache.clear();
+  }
+  await service.start();
 });
 
 program.parse();

--- a/packages/lobe-i18n/src/core/I18n.ts
+++ b/packages/lobe-i18n/src/core/I18n.ts
@@ -33,6 +33,8 @@ export interface I18nTranslateOptions {
 
 export interface I18nMarkdownTranslateOptions
   extends Pick<I18nTranslateOptions, 'from' | 'to' | 'onProgress'> {
+  filePath: string;
+  hash: string;
   matter?: any;
   md: string;
   mode: MarkdownModeType;


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

通过计算每个原始文件的 hash 值缓存 AI 的翻译结果，这个结果并存储在项目的 db 文件。
每次运行时，从 cache 中检查 hash 值，并过滤对应文件。

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
持久化存储使用了 @deno/kv 这个仓库，由于您可能希望使用其它的库，那么在 cache 文件夹里面可以替换这个库