### PR TITLE
[Lobe i18n] Improve Usage section for better onboarding experience

### DIFF
--- a/packages/lobe-i18n/README.md
+++ b/packages/lobe-i18n/README.md
@@ -87,10 +87,31 @@ npm install -g @lobehub/i18n-cli
 
 ## 🤯 Usage
 
+### Step 1: Initialize Configuration
 To initialize the Lobe i18n configuration, run the following command:
 
 ```shell
 $ lobe-i18n -o # or use the full flag --option
+```
+
+### Step 2: Run Translation Commands
+
+This command will guide you through creating a configuration file step by step.
+
+Alternatively, you can manually create a configuration file in one of the formats supported by [cosmiconfig](https://github.com/cosmiconfig/cosmiconfig) (see [Configuration](#configuration) below).
+
+Here's an example of a configuration file (`.i18nrc.js`):  
+This example demonstrates how to generate `locales/zh_CN.json` and `locales/ja_JP.json` automatically based on `locales/en_US.json`.
+
+```javascript
+const { defineConfig } = require('@lobehub/i18n-cli');
+
+module.exports = defineConfig({
+  entry: 'locales/en_US.json',
+  entryLocale: 'en_US',
+  output: 'locales',
+  outputLocales: ['zh_CN', 'ja_JP'],
+});
 ```
 
 > \[!IMPORTANT]\

--- a/packages/lobe-i18n/README.zh-CN.md
+++ b/packages/lobe-i18n/README.zh-CN.md
@@ -87,10 +87,32 @@ npm install -g @lobehub/i18n-cli
 
 ## 🤯 使用
 
+### 第一步：初始化配置
+
 要初始化配置 Lobe i8n，请运行以下命令：
 
 ```shell
 $ lobe-i18n -o # 或使用完整标志 --option
+```
+
+### 第二步：运行翻译命令
+
+此命令将引导您逐步创建配置文件。
+
+或者，您可以手动创建配置文件，支持的格式请参考 [cosmiconfig](https://github.com/cosmiconfig/cosmiconfig) （详见 [Configuration](#configuration)）。
+
+以下是一个配置文件示例（`.i18nrc.js`）：  
+此示例展示了如何基于 `locales/en_US.json` 自动生成 `locales/zh_CN.json` 和 `locales/ja_JP.json`。
+
+```javascript
+const { defineConfig } = require('@lobehub/i18n-cli');
+
+module.exports = defineConfig({
+  entry: 'locales/en_US.json',
+  entryLocale: 'en_US',
+  output: 'locales',
+  outputLocales: ['zh_CN', 'ja_JP'],
+});
 ```
 
 > \[!IMPORTANT]\


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [x] 📝 docs

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

**Background:**  
When I first tried using Lobe i18n, I encountered some confusion in the `Usage` section of the README.
Specifically, the need to create a configuration file (e.g., `.i18nrc.js`) before running commands like `lobe-i18n` wasn’t immediately clear.

**Proposal:**  
This PR updates the `Usage` section to include:
1. A step-by-step guide for initializing the configuration.
2. An example of a `.i18nrc.js` configuration file.

**Goal:**  
By making the setup process clearer, especially for first-time users, this PR aims to improve the onboarding experience.

---

**Request for Review**
I hope this change can contribute to enhancing the usability of Lobe i18n. Please let me know if there are any adjustments or improvements needed.

Thank you for your time and consideration!

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
