### PR TITLE
Add tty check on stdout.clearLine

### DIFF
--- a/packages/lobe-i18n/src/commands/TranslateLocale/index.tsx
+++ b/packages/lobe-i18n/src/commands/TranslateLocale/index.tsx
@@ -97,8 +97,10 @@ class TranslateLocale {
 
     for (const locale of config.outputLocales) {
       for (const [index, filename] of files.entries()) {
-        process.stdout.clearLine(0);
-        process.stdout.cursorTo(0);
+        if (process.stdout.isTTY) {
+          process.stdout.clearLine(0);
+          process.stdout.cursorTo(0);
+        }
 
         process.stdout.write(
           `${chalk.cyan(locale)}${chalk.gray(`[${index + 1}/${files.length}] - `)}${chalk.yellow(filename)}`,
@@ -118,8 +120,10 @@ class TranslateLocale {
       }
     }
 
-    process.stdout.clearLine(0);
-    process.stdout.cursorTo(0);
+    if (process.stdout.isTTY) {
+      process.stdout.clearLine(0);
+      process.stdout.cursorTo(0);
+    }
   }
 
   genFlatQuery() {


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

Fixes the issue where the folder mode cannot be run on non-tty terminal, e.g. Github CI runner.

#### 📝 补充信息 | Additional Information

```
Run npm run locale 2>&1 | cat

> @comfyorg/comfyui-frontend@1.5.12 locale
> lobe-i18n locale

(node:3508) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
[start] Lobe I18N is analyzing your project... 🤯🌏🔍
[info] Running in 📂 Folder Mode and has found 2 files.
file:///home/runner/work/ComfyUI_frontend/ComfyUI_frontend/ComfyUI_frontend/node_modules/@lobehub/i18n-cli/dist/cli.js:9
`,"utf8")},"writeJSON"),Ke=i(e=>rt(e,"utf8"),"readMarkdown"),Ge=i((e,t)=>{ot(e,t,"utf8")},"writeMarkdown"),Ve=i(e=>{for(const t of e.outputLocales){const n=y(e.output,`${t}.json`);v(n)||w(n,{})}},"checkLocales"),Qe=i((e,t)=>{for(const n of e.outputLocales){const o=y(e.output,n);v(o)||st(o)}for(const n of e.outputLocales)for(const o of t){const r=y(e.output,n,o);try{const a=_t(r);st(a,{recursive:!0})}catch{}v(r)||w(r,{})}},"checkLocaleFolders"),ze=i(e=>{try{const t=y("./",e.entry);return v(t)||m.error(`Can't find ${l.bold.yellow(e.entry)} in dir`,!0),_(t)}catch{Yt.exit(1)}},"getEntryFile"),We=i(e=>{const t=e.entry.replaceAll("*","").replaceAll("*.json",""),n=it(W(t,"**/*.json").replaceAll("\\","/"),{nodir:!0}),o={};for(const r of n)o[A(t,r)]=_(r);if(Object.keys(o).length===0){m.error(`Can't find .json files in ${l.bold.yellow(t)}`,!0);return}return o},"getEntryFolderFiles"),yt=i(e=>{const t=_(e);return t||(w(e,{}),{})},"getLocaleObj"),q=i((e,t)=>{try{if(e===t)return!0;if(typeof e!=typeof t)return!1;if(typeof e=="object"&&typeof t=="object"){const n=Object.keys(e),o=Object.keys(t);if(n.length!==o.length)return!1;for(const r of n)if(!o.includes(r)||!q(e[r],t[r]))return!1}return typeof e==typeof t}catch{return!1}},"isEqualJsonKeys");class Xe{static{i(this,"TranslateLocale")}config;query=[];i18n;constructor(){this.config=g.getLocaleConfig(),this.i18n=new ht({config:this.config,openAIApiKey:g.getOpenAIApiKey(),openAIProxyUrl:g.getOpenAIProxyUrl()})}async start(){p.start("Lobe I18N is analyzing your project... \u{1F92F}\u{1F30F}\u{1F50D}"),!this.config.entry.includes(".json")||this.config.entry.includes("*")?this.genFolderQuery():this.genFlatQuery(),this.query.length>0?await this.runQuery():p.success("No content requiring translation was found."),p.success("All i18n tasks have been completed\uFF01")}async runQuery(){p.info(`Current model setting: ${l.cyan(this.config.modelName)} (temperature: ${l.cyan(this.config.temperature)}) ${this.config.experimental?.jsonMode?l.red(" [JSON Mode]"):""}}`);let t=0;for(const n of this.query){const o={filename:n.filename,from:n.from||this.config.entryLocale,to:n.to},{rerender:r,clear:a}=j(d(N,{hide:!0,isLoading:!0,maxStep:1,progress:0,step:0,...o})),s=await this.i18n.translate({...n,onProgress:i(u=>{u.maxStep>0?r(d(N,{...u,...o})):a()},"onProgress")});a();const c=A(".",n.filename);s?.result&&Object.keys(s.result).length>0?(w(n.filename,s.result),t+=s.tokenUsage,p.success(l.yellow(c),l.gray(`[Token usage: ${s.tokenUsage}]`))):p.warn("No translation result was found:",l.yellow(c))}t>0&&p.info("Total token usage:",l.cyan(t))}genFolderQuery(){const t=this.config,n=We(t),o=Object.keys(n);p.info(`Running in ${l.bold.cyan("\u{1F4C2} Folder Mode")} and has found ${l.bold.cyan(o.length)} files.`),Qe(t,o);for(const r of t.outputLocales)for(const[a,s]of o.entries()){process.stdout.clearLine(0),process.stdout.cursorTo(0),process.stdout.write(`${l.cyan(r)}${l.gray(`[${a+1}/${o.length}] - `)}${l.yellow(s)}`);const c=y(t.output,r,s),u=n[s],f=D(u,yt(c)).target;w(c,f),!q(u,f)&&this.query.push({entry:u,filename:c,from:t.entryLocale,target:f,to:r})}process.stdout.clearLine(0),process.stdout.cursorTo(0)}genFlatQuery(){const t=this.config,n=ze(t);p.start(`Running in ${l.bold.cyan("\u{1F4C4} Flat Mode")}, and translating ${l.bold.cyan(t.outputLocales.join("/"))} locales..`),Ve(t);for(const o of t.outputLocales){const r=y(t.output,o)+".json",a=n,s=D(a,yt(r)).target;w(r,s),!q(a,s)&&this.query.push({entry:a,filename:r,from:t.entryLocale,target:s,to:o})}}}const kt=i((e,t)=>e.map(n=>n.includes("*")||n.includes(t)?n:W(n,`**/*${t}`).replaceAll("\\","/")),"matchInputPattern");class wt{static{i(this,"TranslateMarkdown")}config;markdownConfig;query=[];i18n;constructor(){this.markdownConfig=g.getMarkdownConfigFile();const t=g.getConfigFile();this.config={...t,entryLocale:t.entryLocale||this.markdownConfig.entryLocale,markdown:this.markdownConfig,outputLocales:t.outputLocales||this.markdownConfig.outputLocales},this.i18n=new ht({config:this.config,openAIApiKey:g.getOpenAIApiKey(),openAIProxyUrl:g.getOpenAIProxyUrl()})}async start(){p.start("Lobe I18N is analyzing your markdown... \u{1F92F}\u{1F30F}\u{1F50D}");const t=this.markdownConfig.entry;(!t||t.length===0)&&m.error("No markdown entry was found.",!0);let n=it(kt(t,".md"),{ignore:this.markdownConfig.exclude?kt(this.markdownConfig.exclude||[],".md"):void 0,nodir:!0});this.markdownConfig.entryExtension&&(n=n.filter(o=>o.includes(this.markdownConfig.entryExtension||".md"))),(!n||n.length===0)&&m.error("No markdown entry was found.",!0),this.genFilesQuery(n),this.query.length>0?await this.runQuery():p.success("No content requiring translation was found."),p.success("All i18n tasks have been completed\uFF01")}async runQuery(){p.info(`Current model setting: ${l.cyan(this.config.modelName)} (temperature: ${l.cyan(this.config.temperature)}) ${this.config.experimental?.jsonMode?l.red(" [JSON Mode]"):""}}`);let t=0;for(const n of this.query){const o={filename:n.filename,from:n.from||this.markdownConfig.entryLocale||this.config.entryLocale,to:n.to},{rerender:r,clear:a}=j(d(N,{hide:!0,isLoading:!0,maxStep:1,progress:0,step:0,...o})),s=await this.i18n.translateMarkdown({...n,onProgress:i(u=>{u.maxStep>0?r(d(N,{...u,...o})):a()},"onProgress")});a();const c=A(".",n.filename);if(s?.result&&Object.keys(s.result).length>0){let u=s.result;this.markdownConfig.includeMatter||(u=at.stringify(s.result,n.matter)),Ge(n.filename,u),t+=s.tokenUsage,p.success(l.yellow(c),l.gray(`[Token usage: ${s.tokenUsage}]`))}else p.warn("No translation result was found:",l.yellow(c))}t>0&&p.info("Total token usage:",l.cyan(t))}genFilesQuery(t,n){const o=this.markdownConfig;n||p.start(`Running in ${l.bold.cyan(`\u{1F4C4} ${t.length} Markdown`)}, and translating to ${l.bold.cyan(o?.outputLocales?.join("/"))} locales..`);for(const r of t)try{const a=Ke(r);for(const s of o.outputLocales||[]){const c=this.getTargetExtension(s,r,a),u=this.getTargetFilename(r,c);if(v(u))continue;const f=this.getMode(r,a),{data:O,content:x}=at(a);p.info(`\u{1F4C4} To ${s}: ${l.yellow(u)}`),this.query.push({filename:u,from:o.entryLocale,matter:O,md:this.markdownConfig.includeMatter?a:x,mode:f,to:s})}}catch{m.error(`${r} not found`,!0)}}getTargetExtension(t,n,o){return this.markdownConfig.outputExtensions?.(t,{fileContent:o,filePath:n,getDefaultExtension:$})||$(t)}getTargetFilename(t,n){if(this.markdownConfig.entryExtension)return y(".",t.replace(this.markdownConfig.entryExtension||".md",n));if(this.markdownConfig.entryLocale&&t.includes(`.${this.markdownConfig.entryLocale}.`))return[t.split(`.${this.markdownConfig.entryLocale}.`)[0],n].join("");{const o=t.split(".");return o.pop(),[o.join("."),n].join("")}}getMode(t,n){const o=this.markdownConfig.mode;return o?Dt(o)?o:o({fileContent:n,filePath:t})||T.STRING:T.STRING}}const Ye=Mt({pkg:E,shouldNotifyInNpmScript:!0});Ye.notify({isGlobal:!0});const S=new Ot;S.name("lobe-i18n").description(E.description).version(E.version).addOption(new I("-o, --option","Setup lobe-i18n preferences")).addOption(new I("-c, --config <string>","Specify the configuration file")).addOption(new I("-m, --with-md","Run i18n translation and markdown translation simultaneously")),S.command("locale",{isDefault:!0}).action(async()=>{const e=S.opts();e.option?j(d(Fe,{})):(e.config&&P.loadCustomConfig(e.config),await new Xe().start(),e.withMd&&await new wt().start())}),S.command("md").action(async()=>{const e=S.opts();e.config&&P.loadCustomConfig(e.config),await new wt().start()}),S.parse()});export default He();
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            

TypeError: process.stdout.clearLine is not a function
    at Xe.genFolderQuery (file:///home/runner/work/ComfyUI_frontend/ComfyUI_frontend/ComfyUI_frontend/node_modules/@lobehub/i18n-cli/dist/cli.js:9:2850)
    at Xe.start (file:///home/runner/work/ComfyUI_frontend/ComfyUI_frontend/ComfyUI_frontend/node_modules/@lobehub/i18n-cli/dist/cli.js:9:1635)
    at Command.<anonymous> (file:///home/runner/work/ComfyUI_frontend/ComfyUI_frontend/ComfyUI_frontend/node_modules/@lobehub/i18n-cli/dist/cli.js:9:7363)
    at Command.listener [as _actionHandler] (/home/runner/work/ComfyUI_frontend/ComfyUI_frontend/ComfyUI_frontend/node_modules/commander/lib/command.js:542:17)
    at /home/runner/work/ComfyUI_frontend/ComfyUI_frontend/ComfyUI_frontend/node_modules/commander/lib/command.js:1502:14
    at Command._chainOrCall (/home/runner/work/ComfyUI_frontend/ComfyUI_frontend/ComfyUI_frontend/node_modules/commander/lib/command.js:1386:12)
    at Command._parseCommand (/home/runner/work/ComfyUI_frontend/ComfyUI_frontend/ComfyUI_frontend/node_modules/commander/lib/command.js:1501:27)
    at /home/runner/work/ComfyUI_frontend/ComfyUI_frontend/ComfyUI_frontend/node_modules/commander/lib/command.js:1265:27
    at Command._chainOrCall (/home/runner/work/ComfyUI_frontend/ComfyUI_frontend/ComfyUI_frontend/node_modules/commander/lib/command.js:1386:12)
    at Command._dispatchSubcommand (/home/runner/work/ComfyUI_frontend/ComfyUI_frontend/ComfyUI_frontend/node_modules/commander/lib/command.js:1261:25)

Node.js v22.11.0
```