### PR TITLE
🐛 fix: Preserve numeric string keys as objects instead of arrays

### DIFF
--- a/packages/lobe-i18n/src/utils/diffJson.ts
+++ b/packages/lobe-i18n/src/utils/diffJson.ts
@@ -1,8 +1,10 @@
 import { diff as justDiff } from 'just-diff';
-import { cloneDeep, set, unset } from 'lodash-es';
+import { cloneDeep, unset } from 'lodash-es';
 
 import { LocaleObj } from '@/types';
 import { I18nConfig, KeyStyle } from '@/types/config';
+
+import { setByPath } from './setByPath';
 
 type DiffPath = string | Array<number | string>;
 
@@ -45,7 +47,9 @@ export const diff = (
 
   for (const item of add) {
     const path = resolveDiffPath(entry, item.path as DiffPath, keyStyle);
-    set(extra, path, item.value);
+    // Use custom setByPath to preserve numeric string keys as object keys
+    const pathArray = Array.isArray(path) ? path : [path];
+    setByPath(extra, pathArray, item.value);
   }
 
   return {

--- a/packages/lobe-i18n/src/utils/setByPath.test.ts
+++ b/packages/lobe-i18n/src/utils/setByPath.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest';
+
+import { setByPath } from './setByPath';
+
+describe('setByPath', () => {
+  it('should set a simple nested value', () => {
+    const obj = {};
+    setByPath(obj, ['a', 'b', 'c'], 'value');
+    expect(obj).toEqual({ a: { b: { c: 'value' } } });
+  });
+
+  it('should preserve numeric string keys as object keys, not array indices', () => {
+    const obj = {};
+    setByPath(obj, ['nodeDefs', '0', 'name'], 'First Node');
+    setByPath(obj, ['nodeDefs', '1', 'name'], 'Second Node');
+    setByPath(obj, ['nodeDefs', '2', 'name'], 'Third Node');
+
+    expect(obj).toEqual({
+      nodeDefs: {
+        '0': { name: 'First Node' },
+        '1': { name: 'Second Node' },
+        '2': { name: 'Third Node' },
+      },
+    });
+
+    // Verify it's an object, not an array
+    expect(Array.isArray((obj as any).nodeDefs)).toBe(false);
+  });
+
+  it('should handle numeric keys at the root level', () => {
+    const obj = {};
+    setByPath(obj, ['0'], 'value0');
+    setByPath(obj, ['1'], 'value1');
+
+    expect(obj).toEqual({
+      '0': 'value0',
+      '1': 'value1',
+    });
+
+    expect(Array.isArray(obj)).toBe(false);
+  });
+
+  it('should handle mixed numeric and string keys', () => {
+    const obj = {};
+    setByPath(obj, ['items', '0', 'id'], 'first');
+    setByPath(obj, ['items', 'abc', 'id'], 'second');
+    setByPath(obj, ['items', '1', 'id'], 'third');
+
+    expect(obj).toEqual({
+      items: {
+        '0': { id: 'first' },
+        '1': { id: 'third' },
+        'abc': { id: 'second' },
+      },
+    });
+
+    expect(Array.isArray((obj as any).items)).toBe(false);
+  });
+
+  it('should overwrite existing values', () => {
+    const obj = { a: { b: 'old' } };
+    setByPath(obj, ['a', 'b'], 'new');
+    expect(obj).toEqual({ a: { b: 'new' } });
+  });
+
+  it('should handle single-key paths', () => {
+    const obj = {};
+    setByPath(obj, ['key'], 'value');
+    expect(obj).toEqual({ key: 'value' });
+  });
+
+  it('should handle empty path gracefully', () => {
+    const obj = { existing: 'data' };
+    setByPath(obj, [], 'value');
+    // Should not modify the object
+    expect(obj).toEqual({ existing: 'data' });
+  });
+
+  it('should create intermediate objects when path does not exist', () => {
+    const obj = {};
+    setByPath(obj, ['a', 'b', 'c', 'd'], 'value');
+    expect(obj).toEqual({
+      a: {
+        b: {
+          c: {
+            d: 'value',
+          },
+        },
+      },
+    });
+  });
+
+  it('should replace non-object intermediate values with objects', () => {
+    const obj: any = { a: 'string' };
+    setByPath(obj, ['a', 'b'], 'value');
+    expect(obj).toEqual({
+      a: {
+        b: 'value',
+      },
+    });
+  });
+
+  it('should handle complex nested structures with numeric keys', () => {
+    const obj = {};
+    setByPath(obj, ['nodeDefs', '0', 'inputs', '0', 'name'], 'input1');
+    setByPath(obj, ['nodeDefs', '0', 'inputs', '1', 'name'], 'input2');
+    setByPath(obj, ['nodeDefs', '1', 'outputs', '0', 'name'], 'output1');
+
+    expect(obj).toEqual({
+      nodeDefs: {
+        '0': {
+          inputs: {
+            '0': { name: 'input1' },
+            '1': { name: 'input2' },
+          },
+        },
+        '1': {
+          outputs: {
+            '0': { name: 'output1' },
+          },
+        },
+      },
+    });
+
+    // Verify all levels are objects, not arrays
+    const typed = obj as any;
+    expect(Array.isArray(typed.nodeDefs)).toBe(false);
+    expect(Array.isArray(typed.nodeDefs['0'].inputs)).toBe(false);
+    expect(Array.isArray(typed.nodeDefs['1'].outputs)).toBe(false);
+  });
+
+  it('should handle number type in path (not just numeric strings)', () => {
+    const obj = {};
+    setByPath(obj, ['items', 0, 'name'], 'First');
+    setByPath(obj, ['items', 1, 'name'], 'Second');
+
+    expect(obj).toEqual({
+      items: {
+        '0': { name: 'First' },
+        '1': { name: 'Second' },
+      },
+    });
+
+    expect(Array.isArray((obj as any).items)).toBe(false);
+  });
+});

--- a/packages/lobe-i18n/src/utils/setByPath.ts
+++ b/packages/lobe-i18n/src/utils/setByPath.ts
@@ -1,0 +1,32 @@
+/**
+ * Custom implementation of lodash set() that preserves numeric string keys as object keys
+ * instead of converting them to array indices.
+ *
+ * This fixes the issue where objects like {"0": {...}, "1": {...}} were being converted
+ * to arrays during the i18n translation process.
+ *
+ * @param obj - The object to set the value in
+ * @param path - Array of keys representing the path
+ * @param value - The value to set
+ */
+export function setByPath(obj: any, path: Array<string | number>, value: any): void {
+  if (path.length === 0) return;
+
+  let current = obj;
+
+  // Navigate to the parent of the target key
+  for (let i = 0; i < path.length - 1; i++) {
+    const key = String(path[i]); // Always treat keys as strings
+
+    // Create intermediate object if it doesn't exist or is not an object
+    if (!current[key] || typeof current[key] !== 'object') {
+      current[key] = {};
+    }
+
+    current = current[key];
+  }
+
+  // Set the final value
+  const finalKey = String(path.at(-1));
+  current[finalKey] = value;
+}


### PR DESCRIPTION
## Summary
Fixes the issue where objects with numeric string keys (e.g., `{"0": {...}, "1": {...}}`) were being converted to arrays during i18n translation processing.

## Root Cause
The `lodash.set()` function interprets numeric string keys as array indices, which caused:
- Objects like `{"0": "value1", "1": "value2"}` to become arrays `["value1", "value2"]`
- This broke downstream tools expecting object structures (e.g., vue-i18n path resolution)

## Solution
Implemented a custom `setByPath()` function that:
- Always treats keys as object properties, regardless of whether they look numeric
- Preserves the original object structure during translation chunk building
- Passes all 167 existing tests + 11 new tests

## Changes
- Added `packages/lobe-i18n/src/utils/setByPath.ts` - Custom path setter that preserves numeric keys
- Added `packages/lobe-i18n/src/utils/setByPath.test.ts` - Comprehensive tests
- Modified `packages/lobe-i18n/src/utils/diffJson.ts` - Use custom setter instead of lodash

## Test Plan
- [x] All existing tests pass (167/167)
- [x] New unit tests for `setByPath()` (11/11)
- [x] Reproduction tests verify numeric keys remain as objects
- [x] Complex nested numeric keys preserved
- [x] Type checking passes across all packages

## Related
- Comfy-Org/ComfyUI_frontend#8718 - This is the downstream issue that prompted this fix

## Before/After
**Before:**
```json
{
  "nodeDefs": ["node1", "node2"]  // ❌ Array
}
```

**After:**
```json
{
  "nodeDefs": {  // ✅ Object
    "0": "node1",
    "1": "node2"
  }
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Preserve numeric string keys as object properties during i18n diff processing instead of having them coerced into arrays.

Bug Fixes:
- Fix incorrect conversion of objects with numeric string keys into arrays during i18n translation diff building.

Enhancements:
- Introduce a custom path-setting utility that consistently treats all keys as object properties to maintain locale object structure.

Tests:
- Add unit tests for the new path-setting utility and its handling of numeric string keys in nested structures.