### PR TITLE
Using ELD version 2, with static import, instead of fork with await.

### DIFF
--- a/packages/lobe-i18n/package.json
+++ b/packages/lobe-i18n/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@lobehub/cli-ui": "1.13.0",
-    "@yutengjing/eld": "^0.0.2",
+    "eld": "^2.0.3",
     "chalk": "^5.4.1",
     "commander": "^13.0.0",
     "conf": "^13.1.0",

--- a/packages/lobe-i18n/src/commands/Lint/utils/languageDetection.ts
+++ b/packages/lobe-i18n/src/commands/Lint/utils/languageDetection.ts
@@ -1,23 +1,6 @@
-import { eld } from '@yutengjing/eld';
+import { eld } from 'eld/large';
 
 import { LanguageDetectionResult } from '../types';
-
-// 语言检测器初始化Promise，确保只初始化一次
-let initPromise: Promise<void> | null = null;
-
-/**
- * 初始化 ELD 语言检测器
- */
-export async function initializeELD(): Promise<void> {
-  if (!initPromise) {
-    initPromise = (async () => {
-      console.log('🔧 Initializing ELD language detector...');
-      await eld.init('L'); // 使用中等规模的数据集
-      console.log('✅ ELD language detector initialized');
-    })();
-  }
-  return initPromise;
-}
 
 /**
  * 检测文本的语言
@@ -31,9 +14,6 @@ export async function detectLanguage(text: string): Promise<LanguageDetectionRes
       scores: {},
     };
   }
-
-  // 确保 ELD 已初始化
-  await initializeELD();
 
   const result = eld.detect(text);
   const scores = result.getScores();


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change
From:
```js
import { eld } from '@yutengjing/eld';
//...
let initPromise: Promise<void> | null = null;

export async function initializeELD(): Promise<void> {
  if (!initPromise) {
    initPromise = (async () => {
      console.log('🔧 Initializing ELD language detector...');
      await eld.init('L'); // 使用中等规模的数据集
      console.log('✅ ELD language detector initialized');
    })();
  }
  return initPromise;
}
//...
 await initializeELD();
```
To:
```js
import { eld } from 'eld/large';
```

#### 📝 补充信息 | Additional Information


> **Changes from ELD v1 to v2**  
> 
> You can now import static eld with a specific database size:  
> `import { eld } from 'eld/large';`  
> 
> - ELD is now 1.5x faster, and more accurate.
> - TypeScript type definitions exported.
> - **npm** install size reduced by a 70%.
